### PR TITLE
Handle all request methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.8.1](https://github.com/CrowdHailer/raxx_static/tree/0.8.1) - 2019-01-06
+
+### Fixed
+
+- Requests with method other than GET are passed up the stack
+
 ## [0.8.0](https://github.com/CrowdHailer/raxx_static/tree/0.8.0) - 2019-01-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.8.1](https://github.com/CrowdHailer/raxx_static/tree/0.8.1) - 2019-01-06
+## [0.8.1](https://github.com/CrowdHailer/raxx_static/tree/0.8.1) - 2019-01-07
 
 ### Fixed
 
-- Requests with method other than GET are passed up the stack
+- Requests with method other than GET are passed up the stack.
 
 ## [0.8.0](https://github.com/CrowdHailer/raxx_static/tree/0.8.0) - 2019-01-05
 

--- a/lib/raxx/static.ex
+++ b/lib/raxx/static.ex
@@ -93,6 +93,10 @@ defmodule Raxx.Static do
     end
   end
 
+  defp match_request(_request, %__MODULE__{}) do
+    :none
+  end
+
   defp match_request(request, options) when is_list(options) do
     match_request(request, setup(options))
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule RaxxStatic.MixProject do
   def project do
     [
       app: :raxx_static,
-      version: "0.8.0",
+      version: "0.8.1",
       elixir: "~> 1.5",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/raxx/static_test.exs
+++ b/test/raxx/static_test.exs
@@ -54,6 +54,14 @@ defmodule Raxx.StaticTest do
     assert response.status == 204
   end
 
+  test "request for different method is passed up the stack", %{stack: stack} do
+    request = Raxx.request(:POST, "/hello.txt")
+
+    {[response], _} = Raxx.Server.handle_head(stack, request)
+
+    assert response.status == 204
+  end
+
   test "setup options can be passed to the middleware" do
     stack =
       Raxx.Stack.new(


### PR DESCRIPTION
only GET methods return static content. All other HTTP methods should pass up the stack